### PR TITLE
Add fishing behavior for playerbots

### DIFF
--- a/src/PlayerbotAI.cpp
+++ b/src/PlayerbotAI.cpp
@@ -148,6 +148,7 @@ PlayerbotAI::PlayerbotAI(Player* bot)
 
     engines[BOT_STATE_COMBAT] = AiFactory::createCombatEngine(bot, this, aiObjectContext);
     engines[BOT_STATE_NON_COMBAT] = AiFactory::createNonCombatEngine(bot, this, aiObjectContext);
+    engines[BOT_STATE_FISHING] = AiFactory::createNonCombatEngine(bot, this, aiObjectContext);
     engines[BOT_STATE_DEAD] = AiFactory::createDeadEngine(bot, this, aiObjectContext);
     if (sPlayerbotAIConfig->applyInstanceStrategies)
         ApplyInstanceStrategies(bot->GetMapId());
@@ -212,7 +213,8 @@ PlayerbotAI::PlayerbotAI(Player* bot)
     masterIncomingPacketHandlers.AddHandler(CMSG_PUSHQUESTTOPARTY, "quest share");
     botOutgoingPacketHandlers.AddHandler(SMSG_QUESTUPDATE_COMPLETE, "quest update complete");
     botOutgoingPacketHandlers.AddHandler(SMSG_QUESTUPDATE_ADD_KILL, "quest update add kill");
-    // botOutgoingPacketHandlers.AddHandler(SMSG_QUESTUPDATE_ADD_ITEM, "quest update add item"); // SMSG_QUESTUPDATE_ADD_ITEM no longer used
+    // botOutgoingPacketHandlers.AddHandler(SMSG_QUESTUPDATE_ADD_ITEM, "quest update add item"); //
+    // SMSG_QUESTUPDATE_ADD_ITEM no longer used
     botOutgoingPacketHandlers.AddHandler(SMSG_QUEST_CONFIRM_ACCEPT, "confirm quest");
 }
 
@@ -1255,6 +1257,7 @@ void PlayerbotAI::ChangeEngine(BotState type)
                 ChangeEngineOnCombat();
                 break;
             case BOT_STATE_NON_COMBAT:
+            case BOT_STATE_FISHING:
                 ChangeEngineOnNonCombat();
                 break;
             case BOT_STATE_DEAD:
@@ -1425,8 +1428,8 @@ void PlayerbotAI::DoNextAction(bool min)
             master = newMaster;
             botAI->SetMaster(newMaster);
             botAI->ResetStrategies();
-            
-            if (!bot->InBattleground()) 
+
+            if (!bot->InBattleground())
             {
                 botAI->ChangeStrategy("+follow", BOT_STATE_NON_COMBAT);
 
@@ -1437,7 +1440,7 @@ void PlayerbotAI::DoNextAction(bool min)
             }
             else
             {
-                // we're in a battleground, stay with the pack and focus on objective 
+                // we're in a battleground, stay with the pack and focus on objective
                 botAI->ChangeStrategy("-follow", BOT_STATE_NON_COMBAT);
             }
         }
@@ -1700,6 +1703,7 @@ void PlayerbotAI::ResetStrategies(bool load)
 
     AiFactory::AddDefaultCombatStrategies(bot, this, engines[BOT_STATE_COMBAT]);
     AiFactory::AddDefaultNonCombatStrategies(bot, this, engines[BOT_STATE_NON_COMBAT]);
+    AiFactory::AddDefaultNonCombatStrategies(bot, this, engines[BOT_STATE_FISHING]);
     AiFactory::AddDefaultDeadStrategies(bot, this, engines[BOT_STATE_DEAD]);
     if (sPlayerbotAIConfig->applyInstanceStrategies)
         ApplyInstanceStrategies(bot->GetMapId());
@@ -2357,7 +2361,6 @@ std::string PlayerbotAI::GetLocalizedCreatureName(uint32 entry)
     }
     return name;
 }
-
 
 std::string PlayerbotAI::GetLocalizedGameObjectName(uint32 entry)
 {
@@ -3330,13 +3333,14 @@ bool PlayerbotAI::CastSpell(uint32 spellId, Unit* target, Item* itemTarget)
             std::ostringstream out;
             out << "Spell cast failed - ";
             out << "Spell ID: " << spellId << " (" << ChatHelper::FormatSpell(spellInfo) << "), ";
-            out << "Error Code: " << static_cast<int>(result) << " (0x" << std::hex << static_cast<int>(result) << std::dec << "), ";
+            out << "Error Code: " << static_cast<int>(result) << " (0x" << std::hex << static_cast<int>(result)
+                << std::dec << "), ";
             out << "Bot: " << bot->GetName() << ", ";
-    
+
             // Check spell target type
             if (targets.GetUnitTarget())
             {
-                out << "Target: Unit (" << targets.GetUnitTarget()->GetName() 
+                out << "Target: Unit (" << targets.GetUnitTarget()->GetName()
                     << ", Low GUID: " << targets.GetUnitTarget()->GetGUID().GetCounter()
                     << ", High GUID: " << static_cast<uint32>(targets.GetUnitTarget()->GetGUID().GetHigh()) << "), ";
             }
@@ -3352,7 +3356,7 @@ bool PlayerbotAI::CastSpell(uint32 spellId, Unit* target, Item* itemTarget)
                 out << "Target: Item (Low GUID: " << targets.GetItemTarget()->GetGUID().GetCounter()
                     << ", High GUID: " << static_cast<uint32>(targets.GetItemTarget()->GetGUID().GetHigh()) << "), ";
             }
-    
+
             // Check if bot is in trade mode
             if (bot->GetTradeData())
             {
@@ -3360,7 +3364,7 @@ bool PlayerbotAI::CastSpell(uint32 spellId, Unit* target, Item* itemTarget)
                 Item* tradeItem = bot->GetTradeData()->GetTraderData()->GetItem(TRADE_SLOT_NONTRADED);
                 if (tradeItem)
                 {
-                    out << "Trade Item: " << tradeItem->GetEntry() 
+                    out << "Trade Item: " << tradeItem->GetEntry()
                         << " (Low GUID: " << tradeItem->GetGUID().GetCounter()
                         << ", High GUID: " << static_cast<uint32>(tradeItem->GetGUID().GetHigh()) << "), ";
                 }
@@ -3373,7 +3377,7 @@ bool PlayerbotAI::CastSpell(uint32 spellId, Unit* target, Item* itemTarget)
             {
                 out << "Trade Mode: Inactive, ";
             }
-    
+
             TellMasterNoFacing(out);
         }
 
@@ -4312,7 +4316,7 @@ bool PlayerbotAI::AllowActive(ActivityType activityType)
             if (!player || !player->IsInWorld())
                 continue;
 
-			Player* connectedPlayer = ObjectAccessor::FindPlayer(player->GetGUID());
+            Player* connectedPlayer = ObjectAccessor::FindPlayer(player->GetGUID());
             if (!connectedPlayer)
                 continue;
 
@@ -4394,16 +4398,16 @@ uint32 PlayerbotAI::AutoScaleActivity(uint32 mod)
         // Perfrom binary decision if ceiling <= floor: Either all bots are active or none are
         return (maxDiff > diffLimitCeiling) ? 0 : mod;
     }
-    
+
     if (maxDiff > diffLimitCeiling)
         return 0;
-    
+
     if (maxDiff <= diffLimitFloor)
         return mod;
-    
+
     // Calculate lag progress from floor to ceiling (0 to 1)
     double lagProgress = (maxDiff - diffLimitFloor) / (double)(diffLimitCeiling - diffLimitFloor);
-    
+
     // Apply the percentage of active bots (the complement of lag progress) to the mod value
     return static_cast<uint32>(mod * (1 - lagProgress));
 }
@@ -4434,47 +4438,47 @@ void PlayerbotAI::RemoveShapeshift()
 // https://wowpedia.fandom.com/wiki/API_GetAverageItemLevel
 uint32 PlayerbotAI::GetEquipGearScore(Player* player)
 {
-    constexpr uint8 TOTAL_SLOTS = 17;                      // every slot except Body & Tabard
+    constexpr uint8 TOTAL_SLOTS = 17;  // every slot except Body & Tabard
     uint32 sumLevel = 0;
 
     /* ---------- 0.  Detect “ignore off-hand” situations --------- */
     Item* main = player->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_MAINHAND);
-    Item* off  = player->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_OFFHAND);
+    Item* off = player->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_OFFHAND);
 
-    bool ignoreOffhand = false;                           // true → divisor = 16
+    bool ignoreOffhand = false;  // true → divisor = 16
     if (main)
     {
         bool twoHand = (main->GetTemplate()->InventoryType == INVTYPE_2HWEAPON);
         if (twoHand && !player->HasAura(SPELL_TITAN_GRIP))
-            ignoreOffhand = true;                         // classic 2-hander
+            ignoreOffhand = true;  // classic 2-hander
     }
-    else if (!off)                                        // both hands empty
+    else if (!off)  // both hands empty
         ignoreOffhand = true;
 
     /* ---------- 1.  Sum up item-levels -------------------------- */
     for (uint8 slot = EQUIPMENT_SLOT_START; slot < EQUIPMENT_SLOT_END; ++slot)
     {
         if (slot == EQUIPMENT_SLOT_BODY || slot == EQUIPMENT_SLOT_TABARD)
-            continue;                                     // Blizzard never counts these
+            continue;  // Blizzard never counts these
 
         if (ignoreOffhand && slot == EQUIPMENT_SLOT_OFFHAND)
-            continue;                                     // skip off-hand in 2-H case
+            continue;  // skip off-hand in 2-H case
 
         if (Item* it = player->GetItemByPos(INVENTORY_SLOT_BAG_0, slot))
-            sumLevel += it->GetTemplate()->ItemLevel;     // missing items add 0
+            sumLevel += it->GetTemplate()->ItemLevel;  // missing items add 0
     }
 
     /* ---------- 2.  Divide by 17 or 16 -------------------------- */
-    const uint8 divisor = ignoreOffhand ? TOTAL_SLOTS - 1 : TOTAL_SLOTS; // 16 or 17
+    const uint8 divisor = ignoreOffhand ? TOTAL_SLOTS - 1 : TOTAL_SLOTS;  // 16 or 17
     return sumLevel / divisor;
 }
 
 // NOTE : function rewritten as flags "withBags" and "withBank" not used, and _fillGearScoreData sometimes attribute
-// one-hand/2H Weapon in wrong slots 
+// one-hand/2H Weapon in wrong slots
 /*uint32 PlayerbotAI::GetEquipGearScore(Player* player)
 {
     // This function aims to calculate the equipped gear score
- 
+
     uint32 sum = 0;
     uint8 count = EQUIPMENT_SLOT_END - 2;  // ignore body and tabard slots
     uint8 mh_type = 0;
@@ -4483,17 +4487,17 @@ uint32 PlayerbotAI::GetEquipGearScore(Player* player)
     {
         Item* item =player->GetItemByPos(INVENTORY_SLOT_BAG_0, i);
         if (item && i != EQUIPMENT_SLOT_BODY && i != EQUIPMENT_SLOT_TABARD)
-        { 
+        {
             ItemTemplate const* proto = item->GetTemplate();
             sum += proto->ItemLevel;
-            
+
             // If character is not warfury and have 2 hand weapon equipped, main hand will be counted twice
             if (i == SLOT_MAIN_HAND)
                 mh_type = item->GetTemplate()->InventoryType;
             if (!player->HasAura(SPELL_TITAN_GRIP) && mh_type == INVTYPE_2HWEAPON && i == SLOT_MAIN_HAND)
                 sum += item->GetTemplate()->ItemLevel;
-	    }
-    } 
+        }
+    }
 
     uint32 gs = uint32(sum / count);
     return gs;
@@ -4730,7 +4734,7 @@ void PlayerbotAI::_fillGearScoreData(Player* player, Item* item, std::vector<uin
         case INVTYPE_SHOULDERS:
             (*gearScore)[EQUIPMENT_SLOT_SHOULDERS] = std::max((*gearScore)[EQUIPMENT_SLOT_SHOULDERS], level);
             break;
-        case INVTYPE_BODY: //Shouldn't be considered when calculating average ilevel
+        case INVTYPE_BODY:  // Shouldn't be considered when calculating average ilevel
             (*gearScore)[EQUIPMENT_SLOT_BODY] = std::max((*gearScore)[EQUIPMENT_SLOT_BODY], level);
             break;
         case INVTYPE_CHEST:
@@ -5108,48 +5112,50 @@ Item* PlayerbotAI::FindBandage() const
 
 Item* PlayerbotAI::FindOpenableItem() const
 {
-    return FindItemInInventory([this](ItemTemplate const* itemTemplate) -> bool
-    {
-        return (itemTemplate->Flags & ITEM_FLAG_HAS_LOOT) &&
-               (itemTemplate->LockID == 0 || !this->bot->GetItemByEntry(itemTemplate->ItemId)->IsLocked());
-    });
+    return FindItemInInventory(
+        [this](ItemTemplate const* itemTemplate) -> bool
+        {
+            return (itemTemplate->Flags & ITEM_FLAG_HAS_LOOT) &&
+                   (itemTemplate->LockID == 0 || !this->bot->GetItemByEntry(itemTemplate->ItemId)->IsLocked());
+        });
 }
 
 Item* PlayerbotAI::FindLockedItem() const
 {
-    return FindItemInInventory([this](ItemTemplate const* itemTemplate) -> bool
-    {
-        if (!this->bot->HasSkill(SKILL_LOCKPICKING))  // Ensure bot has Lockpicking skill
-            return false;
-
-        if (itemTemplate->LockID == 0)  // Ensure the item is actually locked
-            return false;
-
-        Item* item = this->bot->GetItemByEntry(itemTemplate->ItemId);
-        if (!item || !item->IsLocked())  // Ensure item instance is locked
-            return false;
-
-        // Check if bot has enough Lockpicking skill
-        LockEntry const* lockInfo = sLockStore.LookupEntry(itemTemplate->LockID);
-        if (!lockInfo)
-            return false;
-
-        for (uint8 j = 0; j < 8; ++j)
+    return FindItemInInventory(
+        [this](ItemTemplate const* itemTemplate) -> bool
         {
-            if (lockInfo->Type[j] == LOCK_KEY_SKILL)
+            if (!this->bot->HasSkill(SKILL_LOCKPICKING))  // Ensure bot has Lockpicking skill
+                return false;
+
+            if (itemTemplate->LockID == 0)  // Ensure the item is actually locked
+                return false;
+
+            Item* item = this->bot->GetItemByEntry(itemTemplate->ItemId);
+            if (!item || !item->IsLocked())  // Ensure item instance is locked
+                return false;
+
+            // Check if bot has enough Lockpicking skill
+            LockEntry const* lockInfo = sLockStore.LookupEntry(itemTemplate->LockID);
+            if (!lockInfo)
+                return false;
+
+            for (uint8 j = 0; j < 8; ++j)
             {
-                uint32 skillId = SkillByLockType(LockType(lockInfo->Index[j]));
-                if (skillId == SKILL_LOCKPICKING)
+                if (lockInfo->Type[j] == LOCK_KEY_SKILL)
                 {
-                    uint32 requiredSkill = lockInfo->Skill[j];
-                    uint32 botSkill = this->bot->GetSkillValue(SKILL_LOCKPICKING);
-                    return botSkill >= requiredSkill;
+                    uint32 skillId = SkillByLockType(LockType(lockInfo->Index[j]));
+                    if (skillId == SKILL_LOCKPICKING)
+                    {
+                        uint32 requiredSkill = lockInfo->Skill[j];
+                        uint32 botSkill = this->bot->GetSkillValue(SKILL_LOCKPICKING);
+                        return botSkill >= requiredSkill;
+                    }
                 }
             }
-        }
 
-        return false;
-    });
+            return false;
+        });
 }
 
 static const uint32 uPriorizedSharpStoneIds[8] = {ADAMANTITE_SHARPENING_DISPLAYID, FEL_SHARPENING_DISPLAYID,
@@ -6347,17 +6353,16 @@ void PlayerbotAI::AddTimedEvent(std::function<void()> callback, uint32 delayMs)
     class LambdaEvent final : public BasicEvent
     {
         std::function<void()> _cb;
+
     public:
         explicit LambdaEvent(std::function<void()> cb) : _cb(std::move(cb)) {}
         bool Execute(uint64 /*execTime*/, uint32 /*diff*/) override
         {
             _cb();
-            return true;           // remove after execution
+            return true;  // remove after execution
         }
     };
 
     // Every Player already owns an EventMap called m_Events
-    bot->m_Events.AddEvent(
-        new LambdaEvent(std::move(callback)),
-        bot->m_Events.CalculateTime(delayMs));
+    bot->m_Events.AddEvent(new LambdaEvent(std::move(callback)), bot->m_Events.CalculateTime(delayMs));
 }

--- a/src/PlayerbotAI.h
+++ b/src/PlayerbotAI.h
@@ -73,7 +73,8 @@ enum BotState
 {
     BOT_STATE_COMBAT = 0,
     BOT_STATE_NON_COMBAT = 1,
-    BOT_STATE_DEAD = 2,
+    BOT_STATE_FISHING = 2,
+    BOT_STATE_DEAD = 3,
 
     BOT_STATE_MAX
 };
@@ -493,8 +494,7 @@ public:
     bool CanCastSpell(uint32 spellid, Unit* target, bool checkHasSpell = true, Item* itemTarget = nullptr,
                       Item* castItem = nullptr);
     bool CanCastSpell(uint32 spellid, GameObject* goTarget, bool checkHasSpell = true);
-    bool CanCastSpell(uint32 spellid, float x, float y, float z, bool checkHasSpell = true,
-                      Item* itemTarget = nullptr);
+    bool CanCastSpell(uint32 spellid, float x, float y, float z, bool checkHasSpell = true, Item* itemTarget = nullptr);
 
     bool HasAura(uint32 spellId, Unit const* player);
     Aura* GetAura(std::string const spellName, Unit* unit, bool checkIsOwner = false, bool checkDuration = false,
@@ -510,7 +510,7 @@ public:
                      bool fixed = false);
 
     uint32 GetEquipGearScore(Player* player);
-    //uint32 GetEquipGearScore(Player* player, bool withBags, bool withBank);
+    // uint32 GetEquipGearScore(Player* player, bool withBags, bool withBank);
     static uint32 GetMixedGearScore(Player* player, bool withBags, bool withBank, uint32 topN = 0);
     bool HasSkill(SkillType skill);
     bool IsAllowedCommand(std::string const text);

--- a/src/Playerbots.h
+++ b/src/Playerbots.h
@@ -27,6 +27,9 @@ int strcmpi(char const* s1, char const* s2);
 #define CAST_ANGLE_IN_FRONT (2.f * static_cast<float>(M_PI) / 3.f)
 #define EMOTE_ANGLE_IN_FRONT (2.f * static_cast<float>(M_PI) / 6.f)
 
+// Spell id used for fishing
+#define FISHING_SPELL_ID 131474
+
 #define GET_PLAYERBOT_AI(object) sPlayerbotsMgr->GetPlayerbotAI(object)
 #define GET_PLAYERBOT_MGR(object) sPlayerbotsMgr->GetPlayerbotMgr(object)
 

--- a/src/strategy/actions/ActionContext.h
+++ b/src/strategy/actions/ActionContext.h
@@ -8,8 +8,6 @@
 
 #include "AddLootAction.h"
 #include "AttackAction.h"
-#include "ShareQuestAction.h"
-#include "BattleGroundTactics.h"
 #include "AutoMaintenanceOnLevelupAction.h"
 #include "BattleGroundJoinAction.h"
 #include "BattleGroundTactics.h"
@@ -25,7 +23,9 @@
 #include "CombatActions.h"
 #include "DelayAction.h"
 #include "DestroyItemAction.h"
+#include "DropQuestAction.h"
 #include "EmoteAction.h"
+#include "FishWithMasterAction.h"
 #include "FollowActions.h"
 #include "GenericActions.h"
 #include "GenericSpellActions.h"
@@ -41,10 +41,10 @@
 #include "MoveToRpgTargetAction.h"
 #include "MoveToTravelTargetAction.h"
 #include "MovementActions.h"
+#include "NewRpgAction.h"
 #include "NonCombatActions.h"
 #include "OutfitAction.h"
 #include "PositionAction.h"
-#include "DropQuestAction.h"
 #include "RaidNaxxActions.h"
 #include "RandomBotUpdateAction.h"
 #include "ReachTargetActions.h"
@@ -56,13 +56,13 @@
 #include "RpgSubActions.h"
 #include "RtiAction.h"
 #include "SayAction.h"
+#include "ShareQuestAction.h"
 #include "StayActions.h"
 #include "SuggestWhatToDoAction.h"
 #include "TravelAction.h"
 #include "VehicleActions.h"
 #include "WorldBuffAction.h"
 #include "XpGainAction.h"
-#include "NewRpgAction.h"
 
 class PlayerbotAI;
 
@@ -143,6 +143,7 @@ public:
         creators["drop target"] = &ActionContext::drop_target;
         creators["check mail"] = &ActionContext::check_mail;
         creators["say"] = &ActionContext::say;
+        creators["fish with master"] = &ActionContext::fish_with_master;
         creators["reveal gathering item"] = &ActionContext::reveal_gathering_item;
         creators["outfit"] = &ActionContext::outfit;
         creators["random bot update"] = &ActionContext::random_bot_update;
@@ -217,7 +218,7 @@ public:
         creators["blade salvo"] = &ActionContext::blade_salvo;
         creators["glaive throw"] = &ActionContext::glaive_throw;
 
-        //Rpg
+        // Rpg
         creators["rpg stay"] = &ActionContext::rpg_stay;
         creators["rpg work"] = &ActionContext::rpg_work;
         creators["rpg emote"] = &ActionContext::rpg_emote;
@@ -242,7 +243,7 @@ public:
         creators["rpg mount anim"] = &ActionContext::rpg_mount_anim;
 
         creators["toggle pet spell"] = &ActionContext::toggle_pet_spell;
-        creators["pet attack"] = &ActionContext::pet_attack; 
+        creators["pet attack"] = &ActionContext::pet_attack;
 
         creators["new rpg status update"] = &ActionContext::new_rpg_status_update;
         creators["new rpg go grind"] = &ActionContext::new_rpg_go_grind;
@@ -284,7 +285,10 @@ private:
     static Action* ReachSpell(PlayerbotAI* botAI) { return new ReachSpellAction(botAI); }
     static Action* ReachMelee(PlayerbotAI* botAI) { return new ReachMeleeAction(botAI); }
     static Action* reach_party_member_to_heal(PlayerbotAI* botAI) { return new ReachPartyMemberToHealAction(botAI); }
-    static Action* reach_party_member_to_resurrect(PlayerbotAI* botAI) { return new ReachPartyMemberToResurrectAction(botAI); }
+    static Action* reach_party_member_to_resurrect(PlayerbotAI* botAI)
+    {
+        return new ReachPartyMemberToResurrectAction(botAI);
+    }
     static Action* flee(PlayerbotAI* botAI) { return new FleeAction(botAI); }
     static Action* flee_with_pet(PlayerbotAI* botAI) { return new FleeWithPetAction(botAI); }
     static Action* avoid_aoe(PlayerbotAI* botAI) { return new AvoidAoeAction(botAI); }
@@ -330,6 +334,7 @@ private:
     static Action* set_facing(PlayerbotAI* botAI) { return new SetFacingTargetAction(botAI); }
     static Action* set_behind(PlayerbotAI* botAI) { return new SetBehindTargetAction(botAI); }
     static Action* say(PlayerbotAI* botAI) { return new SayAction(botAI); }
+    static Action* fish_with_master(PlayerbotAI* botAI) { return new FishWithMasterAction(botAI); }
     static Action* reveal_gathering_item(PlayerbotAI* botAI) { return new RevealGatheringItemAction(botAI); }
     static Action* outfit(PlayerbotAI* botAI) { return new OutfitAction(botAI); }
     static Action* random_bot_update(PlayerbotAI* botAI) { return new RandomBotUpdateAction(botAI); }
@@ -377,7 +382,10 @@ private:
     // BG Tactics
     static Action* bg_tactics(PlayerbotAI* botAI) { return new BGTactics(botAI); }
     static Action* bg_move_to_start(PlayerbotAI* botAI) { return new BGTactics(botAI, "move to start"); }
-    static Action* bg_reset_objective_force(PlayerbotAI* botAI) { return new BGTactics(botAI, "reset objective force"); }
+    static Action* bg_reset_objective_force(PlayerbotAI* botAI)
+    {
+        return new BGTactics(botAI, "reset objective force");
+    }
     static Action* bg_move_to_objective(PlayerbotAI* botAI) { return new BGTactics(botAI, "move to objective"); }
     static Action* bg_select_objective(PlayerbotAI* botAI) { return new BGTactics(botAI, "select objective"); }
     static Action* bg_check_objective(PlayerbotAI* botAI) { return new BGTactics(botAI, "check objective"); }

--- a/src/strategy/actions/ChatActionContext.h
+++ b/src/strategy/actions/ChatActionContext.h
@@ -22,6 +22,7 @@
 #include "DestroyItemAction.h"
 #include "DropQuestAction.h"
 #include "EquipAction.h"
+#include "FishWithMasterAction.h"
 #include "FlagAction.h"
 #include "Formations.h"
 #include "GoAction.h"
@@ -39,6 +40,7 @@
 #include "MailAction.h"
 #include "NamedObjectContext.h"
 #include "NewRpgAction.h"
+#include "OpenItemAction.h"
 #include "PassLeadershipToMasterAction.h"
 #include "PositionAction.h"
 #include "QueryItemUsageAction.h"
@@ -70,14 +72,13 @@
 #include "TradeAction.h"
 #include "TrainerAction.h"
 #include "UnequipAction.h"
+#include "UnlockItemAction.h"
+#include "UnlockTradedItemAction.h"
 #include "UseItemAction.h"
 #include "UseMeetingStoneAction.h"
 #include "WhoAction.h"
 #include "WipeAction.h"
 #include "WtsAction.h"
-#include "OpenItemAction.h"
-#include "UnlockItemAction.h"
-#include "UnlockTradedItemAction.h"
 
 class ChatActionContext : public NamedObjectContext<Action>
 {
@@ -171,6 +172,7 @@ public:
         creators["wts"] = &ChatActionContext::wts;
         creators["hire"] = &ChatActionContext::hire;
         creators["craft"] = &ChatActionContext::craft;
+        creators["fish"] = &ChatActionContext::fish_with_master;
         creators["flag"] = &ChatActionContext::flag;
         creators["give leader"] = &ChatActionContext::give_leader;
         creators["cheat"] = &ChatActionContext::cheat;
@@ -196,6 +198,7 @@ private:
     static Action* range(PlayerbotAI* botAI) { return new RangeAction(botAI); }
     static Action* flag(PlayerbotAI* botAI) { return new FlagAction(botAI); }
     static Action* craft(PlayerbotAI* botAI) { return new SetCraftAction(botAI); }
+    static Action* fish_with_master(PlayerbotAI* botAI) { return new FishWithMasterAction(botAI); }
     static Action* hire(PlayerbotAI* botAI) { return new HireAction(botAI); }
     static Action* wts(PlayerbotAI* botAI) { return new WtsAction(botAI); }
     static Action* cs(PlayerbotAI* botAI) { return new CustomStrategyEditAction(botAI); }
@@ -225,7 +228,10 @@ private:
     static Action* runaway_chat_shortcut(PlayerbotAI* botAI) { return new GoawayChatShortcutAction(botAI); }
     static Action* stay_chat_shortcut(PlayerbotAI* botAI) { return new StayChatShortcutAction(botAI); }
     static Action* follow_chat_shortcut(PlayerbotAI* botAI) { return new FollowChatShortcutAction(botAI); }
-    static Action* move_from_group_chat_shortcut(PlayerbotAI* botAI) { return new MoveFromGroupChatShortcutAction(botAI); }
+    static Action* move_from_group_chat_shortcut(PlayerbotAI* botAI)
+    {
+        return new MoveFromGroupChatShortcutAction(botAI);
+    }
     static Action* gb(PlayerbotAI* botAI) { return new GuildBankAction(botAI); }
     static Action* bank(PlayerbotAI* botAI) { return new BankAction(botAI); }
     static Action* help(PlayerbotAI* botAI) { return new HelpAction(botAI); }

--- a/src/strategy/actions/FishWithMasterAction.cpp
+++ b/src/strategy/actions/FishWithMasterAction.cpp
@@ -1,0 +1,57 @@
+#include "FishWithMasterAction.h"
+
+#include <cmath>
+
+#include "Playerbots.h"
+
+bool FishWithMasterAction::isUseful()
+{
+    Player* master = botAI->GetMaster();
+    return master && botAI->GetState() != BOT_STATE_COMBAT;
+}
+
+bool FishWithMasterAction::Execute(Event /*event*/)
+{
+    Player* master = botAI->GetMaster();
+    if (!master)
+        return false;
+
+    if (sServerFacade->GetDistance2d(bot, master) > 10.0f)
+        MoveNear(master, 1.5f);
+
+    bot->StopMoving();
+    bot->SetFacingTo(master);
+    bot->SetFacingTo(master->GetOrientation());
+
+    Item* pole = botAI->FindItemInInventory(
+        [](ItemTemplate const* proto) -> bool
+        { return proto->Class == ITEM_CLASS_WEAPON && proto->SubClass == ITEM_SUBCLASS_WEAPON_FISHING_POLE; });
+
+    if (!pole)
+    {
+        botAI->TellMaster("I need a fishing pole.");
+        return false;
+    }
+
+    Item* main = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_MAINHAND);
+    if (!main || main->GetTemplate()->SubClass != ITEM_SUBCLASS_WEAPON_FISHING_POLE)
+    {
+        WorldPacket packet(CMSG_AUTOEQUIP_ITEM_SLOT, 2);
+        packet << pole->GetGUID() << uint8(EQUIPMENT_SLOT_MAINHAND);
+        bot->GetSession()->HandleAutoEquipItemSlotOpcode(packet);
+    }
+
+    float x = master->GetPositionX() + std::cos(master->GetOrientation()) * 2.0f;
+    float y = master->GetPositionY() + std::sin(master->GetOrientation()) * 2.0f;
+    float z = master->GetPositionZ();
+
+    botAI->CastSpell(FISHING_SPELL_ID, x, y, z);
+    botAI->TellMaster("Fishing started");
+
+    botAI->ChangeEngine(BOT_STATE_FISHING);
+
+    uint32 biteDelay = urand(10000, 30000);
+    botAI->AddTimedEvent([this]() { botAI->TellMaster("Caught something"); }, biteDelay);
+
+    return true;
+}

--- a/src/strategy/actions/FishWithMasterAction.h
+++ b/src/strategy/actions/FishWithMasterAction.h
@@ -1,0 +1,16 @@
+#ifndef _PLAYERBOT_FISHWITHMASTERACTION_H
+#define _PLAYERBOT_FISHWITHMASTERACTION_H
+
+#include "MovementActions.h"
+
+class FishWithMasterAction : public MovementAction
+{
+public:
+    FishWithMasterAction(PlayerbotAI* botAI, std::string const name = "fish with master") : MovementAction(botAI, name)
+    {
+    }
+    bool Execute(Event event) override;
+    bool isUseful() override;
+};
+
+#endif

--- a/src/strategy/actions/SeeSpellAction.cpp
+++ b/src/strategy/actions/SeeSpellAction.cpp
@@ -6,12 +6,13 @@
 #include "SeeSpellAction.h"
 
 #include "Event.h"
+#include "FishWithMasterAction.h"
 #include "Formations.h"
 #include "PathGenerator.h"
 #include "Playerbots.h"
+#include "PositionValue.h"
 #include "RTSCValues.h"
 #include "RtscAction.h"
-#include "PositionValue.h"
 
 Creature* SeeSpellAction::CreateWps(Player* wpOwner, float x, float y, float z, float o, uint32 entry, Creature* lastWp,
                                     bool important)
@@ -44,6 +45,13 @@ bool SeeSpellAction::Execute(Event event)
 
     // if (!botAI->HasStrategy("RTSC", botAI->GetState()))
     //     return false;
+
+    if (spellId == FISHING_SPELL_ID)
+    {
+        FishWithMasterAction act(botAI);
+        act.Execute(Event());
+        return false;
+    }
 
     if (spellId != RTSC_MOVE_SPELL)
         return false;


### PR DESCRIPTION
## Summary
- introduce `FishWithMasterAction` to mimic master's fishing
- add new fishing state and related engine setup
- respond to `.bot fish` and master's fishing spell

## Testing
- `clang-format`

------
https://chatgpt.com/codex/tasks/task_e_686c349a99f8832498d14af630aa90d4